### PR TITLE
Fix bug with AdaptSize statSize update

### DIFF
--- a/src/caches/lru_variants.cpp
+++ b/src/caches/lru_variants.cpp
@@ -242,7 +242,7 @@ bool AdaptSizeCache::lookup(SimpleRequest& req)
     reconfigure();
 
     uint64_t tmpCacheObject0 = req._id;
-    auto size = _size_map[tmpCacheObject0];
+    auto size = req.get_size();
     if(_intervalMetadata.count(tmpCacheObject0)==0
        && _longTermMetadata.count(tmpCacheObject0)==0) {
         // new object


### PR DESCRIPTION
statSize is only incremented the first time the object was seen in which case the size from _sizeMap is 0 - this caused AdaptSize to not adapt.